### PR TITLE
ターゲットフレームワークをv4.8に更新

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -36,7 +36,7 @@ jobs:
       run: msbuild $env:Solution_Name /p:Configuration=Release /p:DefineConstants=CI_BUILD -p:OutDir="out/"
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Build Result
         path: ${{ env.Project_Directory }}\out

--- a/Namalyzer/Namalyzer.csproj
+++ b/Namalyzer/Namalyzer.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>Namalyzer</RootNamespace>
     <AssemblyName>Namalyzer</AssemblyName>
     <ApplicationIcon>eelpitcher.ico</ApplicationIcon>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <UpgradeBackupLocation>

--- a/Namalyzer/Properties/Resources.Designer.cs
+++ b/Namalyzer/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Namalyzer.Properties {
     // または Visual Studio のようなツールを使用して自動生成されました。
     // メンバーを追加または削除するには、.ResX ファイルを編集して、/str オプションと共に
     // ResGen を実行し直すか、または VS プロジェクトをビルドし直します。
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/Namalyzer/Properties/Settings.Designer.cs
+++ b/Namalyzer/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace Namalyzer.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.4.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.13.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/Namalyzer/app.config
+++ b/Namalyzer/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>


### PR DESCRIPTION
プロジェクトファイル `Namalyzer.csproj` のターゲットフレームワークを `v4.7.2` から `v4.8` に変更しました。 リソースファイル `Resources.Designer.cs` と設定ファイル `Settings.Designer.cs` の生成コードバージョンをそれぞれ `16.0.0.0` から `17.0.0.0`、`16.4.0.0` から `17.13.0.0` に更新しました。 また、設定ファイル `app.config` のサポートされるランタイムのバージョンも `v4.7.2` から `v4.8` に変更しました。